### PR TITLE
Fix IP address in announce message

### DIFF
--- a/src/tracker.js
+++ b/src/tracker.js
@@ -85,7 +85,7 @@ function buildAnnounceReq(connId, torrent, port=6881) {
   // event
   buf.writeUInt32BE(0, 80);
   // ip address
-  buf.writeUInt32BE(0, 80);
+  buf.writeUInt32BE(0, 84);
   // key
   crypto.randomBytes(4).copy(buf, 88);
   // num want


### PR DESCRIPTION
It appears the IP address should start in the buffer at byte 84, not 80. 