### PR TITLE
corrected the length of buffer in buildBitfield function in message.js

### DIFF
--- a/src/message.js
+++ b/src/message.js
@@ -70,7 +70,7 @@ module.exports.buildHave = payload => {
 };
 
 module.exports.buildBitfield = bitfield => {
-  const buf = Buffer.alloc(14);
+  const buf = Buffer.alloc(bitfield.length + 1 + 4);
   // length
   buf.writeUInt32BE(payload.length + 1, 0);
   // id


### PR DESCRIPTION
I corrected the length of bitfield buffer according to specifications.
![Screenshot from 2020-12-17 19-41-42](https://user-images.githubusercontent.com/58565094/102498560-25ea7700-40a0-11eb-9d1e-b345d10ea831.png)
